### PR TITLE
Unable to fetch version in `create a new release` if artifact was created using `Latest from default branch` for `default version` property

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -108,7 +108,7 @@
 					},
 					{
 						"name": "CommitsFromSelectedBranch",
-						"endpointUrl": "{{{endpoint.url}}}api/v4/projects/{{{definition}}}/repository/commits?ref_name={{{branch}}}",
+						"endpointUrl": "{{{endpoint.url}}}api/v4/projects/{{{definition}}}/repository/commits{{#if branch}}?ref_name={{{branch}}}",
 						"resultSelector": "jsonpath:$[*]"
 					},
 					{


### PR DESCRIPTION
**Bug:** Unable to fetch version in `create a new release` if artifact was created using `Latest from default branch` for `default version` property.

**Repo Steps:**
1. Install the Gitlab extension and create a new server connection.
2. Create an artifact for a Release and use `Latest from default branch` as `Default version`. `Save` your changes
3. Click on `Create a Release` button and under Artifacts, we won't be able to fetch version for the Source alias

**Reason behind Bug:** Code passes invalid params to REST API under `CommitsFromSelectedBranch`. Here, we even if `branch` is empty we are passing query param `ref_name`.

**Resolution:** Do not pass `ref_name` if the `branch` is empty.